### PR TITLE
Out of range fix

### DIFF
--- a/generators/mt19937.cl
+++ b/generators/mt19937.cl
@@ -49,6 +49,7 @@ uint _mt19937_uint(mt19937_state* state){
 	else{
         y = (state->mt[MT19937_N-1]&MT19937_UPPER_MASK)|(state->mt[0]&MT19937_LOWER_MASK);
         state->mt[MT19937_N-1] = state->mt[MT19937_M-1] ^ (y >> 1) ^ mag01[y & 0x1];
+        state->mti = 0;
 	}
     y = state->mt[state->mti++];
 	state->mti %= MT19937_N;

--- a/generators/mt19937.cl
+++ b/generators/mt19937.cl
@@ -52,7 +52,6 @@ uint _mt19937_uint(mt19937_state* state){
         state->mti = 0;
 	}
     y = state->mt[state->mti++];
-	state->mti %= MT19937_N;
 		
     /* Tempering */
     y ^= (y >> 11);


### PR DESCRIPTION
Let's imagine first function execution. Initially state->mti = 624, execution follows next lines:
41 (if), 
45 (else if),
49-52 (else block)
and than... 
53| y = state->mt[state->mti++];
.. but "state->ms" size is not allow get value from state->ms[624]!
Suppose we need to reset mti?